### PR TITLE
add missing header files to build sdrangel (archlinux)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ set(dsdcc_SOURCES
 set(dsdcc_HEADERS
     descramble.h
     dmr.h
+    dmr_voice.h
+    dmr_data.h
     dsd_decoder.h
     dsd_filters.h
     dsd_logger.h


### PR DESCRIPTION
before:
![screenshot_20161019_102429](https://cloud.githubusercontent.com/assets/5028336/19511142/4b2664fc-95e6-11e6-8ee1-9f13642ccaee.png)

After I add this two header files I could build sdrangel without any problems.
