### PR TITLE
fix building on Apple Clang 8

### DIFF
--- a/nxdnconvolution.cpp
+++ b/nxdnconvolution.cpp
@@ -21,6 +21,7 @@
 
 #include "nxdnconvolution.h"
 
+#include <cstdlib>
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>


### PR DESCRIPTION
error: call to "abs" is ambiguous