### PR TITLE
Fix spelling errors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,7 +81,7 @@ Since version 1.6 dsdccx has the capability of sending regularly the traffic sta
 ---
 
 
-<h1>Developpers notes</h1>
+<h1>Developers notes</h1>
 
 <h2>Structure overview</h2>
 

--- a/crc.cpp
+++ b/crc.cpp
@@ -314,7 +314,7 @@ void DStarCRC::compute_crc(unsigned char *array, int size_buffer)
 	for (int n = 0; n < (size_buffer - 2); n++)
 	{
 		for (int m = 0; m < 8; m++)
-		{    //each bit must be calculated separatly
+		{    //each bit must be calculated separately
 			fcsbit(bitRead(array[n], m));
 		}
 	}

--- a/debian/manpage.xml.ex
+++ b/debian/manpage.xml.ex
@@ -270,7 +270,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
   </refsect1>
   <refsect1 id="see_also">
     <title>SEE ALSO</title>
-    <!-- In alpabetical order. -->
+    <!-- In alphabetical order. -->
     <para><citerefentry>
         <refentrytitle>bar</refentrytitle>
         <manvolnum>1</manvolnum>

--- a/debian/watch.ex
+++ b/debian/watch.ex
@@ -13,7 +13,7 @@ version=4
 #http://example.com/downloads.html \
 #  files/dsdcc-([\d\.]+)\.tar\.gz debian uupdate
 
-# Uncommment to examine a FTP server
+# Uncomment to examine a FTP server
 #ftp://ftp.example.com/pub/dsdcc-(.*)\.tar\.gz debian uupdate
 
 # SourceForge hosted projects

--- a/dpmr.h
+++ b/dpmr.h
@@ -36,7 +36,7 @@ public:
 		DPMRPayloadFrame,    //!< payload superframe with undetermined type
         DPMRVoiceframe,      //!< voice superframe (no SLD)
         DPMRDataVoiceframe,  //!< data and voice superframe (type 2)
-        DPMRData1frame,      //!< data superframe wihout FEC
+        DPMRData1frame,      //!< data superframe without FEC
         DPMRData2frame,      //!< data superframe with FEC
 		DPMREndFrame,        //!< end frame
     } DPMRFrameType;

--- a/dsd_main.cpp
+++ b/dsd_main.cpp
@@ -149,7 +149,7 @@ void usage()
 #endif
     fprintf(stderr, "  -H            Use high-pass filter on audio when using mbelib\n");
     fprintf(stderr, "  -P <float>    Own latitude in decimal degrees. Latitude is positive to the North. Default 0\n");
-    fprintf(stderr, "  -Q <float>    Own longitue in decimal degrees. Longitude is positive to the East. Default 0\n");
+    fprintf(stderr, "  -Q <float>    Own longitude in decimal degrees. Longitude is positive to the East. Default 0\n");
     fprintf(stderr, "                This is useful when status messages (see -M option) contain geographical data\n");
     fprintf(stderr, "                Practically this is only applicable to D-Star\n");
     fprintf(stderr, "  -x            Disable symbol PLL lock\n");

--- a/dstar.cpp
+++ b/dstar.cpp
@@ -332,7 +332,7 @@ void DSDDstar::processSlowData(bool firstFrame)
 
         if (firstFrame)
         {
-            // unconditionnaly reset counters for elements that are always contained in the same 20 frame sequence
+            // unconditionally reset counters for elements that are always contained in the same 20 frame sequence
             m_slowData.radioHeaderIndex = 0;
 
             // initializations based on data type

--- a/messagefile.md
+++ b/messagefile.md
@@ -8,7 +8,7 @@ The polling period will match an actual time interval only during live operation
 
 <h2>File format</h2>
 
-There is one line per polling occurence with a fixed format depending on the protocol. For all protocols the line starts with a timestamp and a protocol identifier. Details by protocol are given next.
+There is one line per polling occurrence with a fixed format depending on the protocol. For all protocols the line starts with a timestamp and a protocol identifier. Details by protocol are given next.
 
 <h3>DMR</h3>
 
@@ -67,7 +67,7 @@ There is one line per polling occurence with a fixed format depending on the pro
   - **3**: dPMR frame type:
     - --: Undefined
     - HD: Header of FS1 type
-    - PY: Payload frame of a sitll undetermined type
+    - PY: Payload frame of a still undetermined type
     - VO: Voice frame
     - VD: Voice and data frame
     - D1: Data without FEC frame

--- a/viterbi.cpp
+++ b/viterbi.cpp
@@ -221,7 +221,7 @@ void Viterbi::encodeToBits(
 void Viterbi::decodeFromBits(
         unsigned char *dataBits,      //!< Decoded output data bits
         const unsigned char *bits,    //!< Input bits
-        unsigned int nbBits,          //!< Number of imput bits
+        unsigned int nbBits,          //!< Number of input bits
         unsigned int startstate)      //!< Encoder starting state
 
 {
@@ -251,7 +251,7 @@ void Viterbi::decodeFromBits(
 void Viterbi::decodeFromSymbols(
         unsigned char *dataBits,      //!< Decoded output data bits
         const unsigned char *symbols, //!< Input symbols
-        unsigned int nbSymbols,       //!< Number of imput symbols
+        unsigned int nbSymbols,       //!< Number of input symbols
         unsigned int startstate)      //!< Encoder starting state
 
 {

--- a/viterbi.h
+++ b/viterbi.h
@@ -52,7 +52,7 @@ public:
     virtual void decodeFromSymbols(
         unsigned char *dataBits,    //!< Decoded output data bits
         const unsigned char *symbols,     //!< Input symbols
-        unsigned int nbSymbols,     //!< Number of imput symbols
+        unsigned int nbSymbols,     //!< Number of input symbols
         unsigned int startstate     //!< Encoder starting state
     );
 
@@ -60,7 +60,7 @@ public:
     virtual void decodeFromBits(
         unsigned char *dataBits,    //!< Decoded output data bits
         const unsigned char *bits,  //!< Input bits
-        unsigned int nbBits,        //!< Number of imput bits
+        unsigned int nbBits,        //!< Number of input bits
         unsigned int startstate     //!< Encoder starting state
     );
 

--- a/viterbi3.cpp
+++ b/viterbi3.cpp
@@ -37,7 +37,7 @@ Viterbi3::~Viterbi3()
 void Viterbi3::decodeFromBits(
         unsigned char *dataBits,      //!< Decoded output data bits
         const unsigned char *bits,    //!< Input bits
-        unsigned int nbBits,          //!< Number of imput bits
+        unsigned int nbBits,          //!< Number of input bits
         unsigned int startstate)      //!< Encoder starting state
 
 {
@@ -67,7 +67,7 @@ void Viterbi3::decodeFromBits(
 void Viterbi3::decodeFromSymbols(
         unsigned char *dataBits,      //!< Decoded output data bits
         const unsigned char *symbols, //!< Input symbols
-        unsigned int nbSymbols,       //!< Number of imput symbols
+        unsigned int nbSymbols,       //!< Number of input symbols
         unsigned int startstate)      //!< Encoder starting state
 
 {

--- a/viterbi3.h
+++ b/viterbi3.h
@@ -35,7 +35,7 @@ public:
     virtual void decodeFromSymbols(
             unsigned char *dataBits,      //!< Decoded output data bits
             const unsigned char *symbols, //!< Input symbols
-            unsigned int nbSymbols,       //!< Number of imput symbols
+            unsigned int nbSymbols,       //!< Number of input symbols
             unsigned int startstate       //!< Encoder starting state
     );
 
@@ -43,7 +43,7 @@ public:
     virtual void decodeFromBits(
         unsigned char *dataBits,    //!< Decoded output data bits
         const unsigned char *bits,  //!< Input bits
-        unsigned int nbBits,        //!< Number of imput bits
+        unsigned int nbBits,        //!< Number of input bits
         unsigned int startstate     //!< Encoder starting state
     );
 

--- a/viterbi5.cpp
+++ b/viterbi5.cpp
@@ -67,7 +67,7 @@ void Viterbi5::decodeFromBits(
 void Viterbi5::decodeFromSymbols(
         unsigned char *dataBits,      //!< Decoded output data bits
         const unsigned char *symbols, //!< Input symbols
-        unsigned int nbSymbols,       //!< Number of imput symbols
+        unsigned int nbSymbols,       //!< Number of input symbols
         unsigned int startstate)      //!< Encoder starting state
 
 {

--- a/viterbi5.h
+++ b/viterbi5.h
@@ -35,7 +35,7 @@ public:
     virtual void decodeFromSymbols(
             unsigned char *dataBits,    //!< Decoded output data bits
             const unsigned char *symbols,     //!< Input symbols
-            unsigned int nbSymbols,     //!< Number of imput symbols
+            unsigned int nbSymbols,     //!< Number of input symbols
             unsigned int startstate     //!< Encoder starting state
     );
 
@@ -43,7 +43,7 @@ public:
     virtual void decodeFromBits(
         unsigned char *dataBits,    //!< Decoded output data bits
         const unsigned char *bits,  //!< Input bits
-        unsigned int nbBits,        //!< Number of imput bits
+        unsigned int nbBits,        //!< Number of input bits
         unsigned int startstate     //!< Encoder starting state
     );
 


### PR DESCRIPTION
This PR fixes one small error in the output of --help (s/longitue/longitude/) and others in the documentation and in some comments.

Fixed with:
codespell --ignore-words-list=cach,ehr,pres --write-changes