### PR TITLE
Initialize DMR basic privacy key to zero

### DIFF
--- a/dsd_opts.cpp
+++ b/dsd_opts.cpp
@@ -25,6 +25,7 @@ DSDOpts::DSDOpts()
     errorbars = 1;
     symboltiming = 0;
     verbose = 2;
+    dmr_bp_key = 0;
     p25enc = 0;
     p25lc = 0;
     p25status = 0;


### PR DESCRIPTION
DMR audio output is sometimes garbled. This occurs because the `dmr_bp_key` variable is not initialized, and may therefore contain a random value. Valgrind detects the bug:
```
==1057659== Conditional jump or move depends on uninitialised value(s)
==1057659==    at 0x486F0DD: DSDcc::DSDDMR::BasicPrivacyXOR(unsigned char*, int) (in /home/argilo/prefix_311/lib/libdsdcc.so.1.9.0)
==1057659==    by 0x48700FD: DSDcc::DSDDMR::processVoiceDibit(unsigned char) (in /home/argilo/prefix_311/lib/libdsdcc.so.1.9.0)
==1057659==    by 0x48708CE: DSDcc::DSDDMR::processVoiceFirstHalf(unsigned int) (in /home/argilo/prefix_311/lib/libdsdcc.so.1.9.0)
==1057659==    by 0x48719A5: DSDcc::DSDDecoder::processFrameInit() (in /home/argilo/prefix_311/lib/libdsdcc.so.1.9.0)
==1057659==    by 0x10AD00: main (in /home/argilo/prefix_311/bin/dsdccx)
```
Initializing this field to zero fixes the problem.