### PR TITLE
Do not memset after the end of the array

### DIFF
--- a/nxdn.cpp
+++ b/nxdn.cpp
@@ -257,7 +257,7 @@ DSDNXDN::DSDNXDN(DSDDecoder *dsdDecoder) :
         y(0),
         z(0)
 {
-    memset(m_syncBuffer, 0, 11);
+    memset(m_syncBuffer, 0, 10);
     memset(m_lichBuffer, 0, 8);
 
     m_rfChannel = NXDNRFCHUnknown;


### PR DESCRIPTION
Fixes an error found by cppcheck:
nxdn.cpp:260:12: error: Buffer is accessed out of bounds: m_syncBuffer [bufferAccessOutOfBounds]